### PR TITLE
Add support for importing Adobe Color Table files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Import colors from swatches file to Sketch.  **(For Sketch 53+)**
 | -------------------------- | ---------------- | ----------------------------------- |
 | Apple Color Picker Palette | `.clr`           | macOS Color Picker <sup>1</sup>     |
 | Adobe Color Swatch         | `.aco`           | Photoshop <sup>2</sup>              |
+| Adobe Color Table          | `.act`           | Photoshop <sup>2</sup>              |
 | Adobe Swatch Exchange      | `.ase`           | Photoshop, Illustrator <sup>2</sup> |
 | GIMP Palette               | `.gpl`           | GIMP, Inkscape                      |
 | Sketch Palette             | `.sketchpalette` | Sketch (old version)                |

--- a/src/import.js
+++ b/src/import.js
@@ -9,6 +9,7 @@ import color from './lib/color';
 import clr2colors from './lib/clr-to-colors';
 import gpl2colors from './lib/gpl-to-colors';
 import aco2colors from './lib/aco-to-colors';
+import act2colors from './lib/act-to-colors';
 import ase2colors from './lib/ase-to-colors';
 import sketchpreset2colors from './lib/sketchpreset-to-colors';
 import sketchpalette2colors from './lib/sketchpalette-to-colors';
@@ -21,6 +22,7 @@ export default function(context) {
         filters: [
             { name: 'Apple Color Picker Palette', extensions: [ 'clr' ] },
             { name: 'Adobe Color Swatch', extensions: [ 'aco' ] },
+            { name: 'Adobe Color Table', extensions: [ 'act' ] },
             { name: 'Adobe Swatch Exchange', extensions: [ 'ase' ] },
             { name: 'GIMP Palette', extensions: [ 'gpl' ] },
             { name: 'Sketch', extensions: [ 'sketchpreset', 'sketchpalette', 'sketch' ] },
@@ -37,6 +39,8 @@ export default function(context) {
             colors = clr2colors(filePath);
         } else if (fileType === '.aco') {
             colors = aco2colors(filePath);
+          } else if (fileType === '.act') {
+            colors = act2colors(filePath);
         } else if (fileType === '.ase') {
             colors = ase2colors(filePath);
         } else if (fileType === '.gpl') {
@@ -130,8 +134,8 @@ export default function(context) {
                 }
             }
 
-        } 
-        
+        }
+
         else if (identifier === 'convert-colors-to-clr-file') {
             dialog.showSaveDialog(
                 {
@@ -208,14 +212,14 @@ export default function(context) {
             });
 
             colors.forEach((item, index) => {
-                
+
                 // Add colors
                 let newName = color.cleanName(item.name);
                 document.colors.push({
                     name: newName,
                     color: item.color
                 });
-                
+
                 // Add layers 5 x 4
                 if (index < 20) {
                     let x = index % 5;
@@ -224,7 +228,7 @@ export default function(context) {
                         name: 'shape',
                         parent: artboard,
                         frame: new Rectangle(x * 40, y * 40, 40, 40),
-                        style: { 
+                        style: {
                             fills: [ { color: item.color } ]
                         }
                     });
@@ -260,13 +264,13 @@ export default function(context) {
                     let allLibraries = sketch.getLibraries().map(item => {
                         return String(item.sketchObject.locationOnDisk().path());
                     });
-        
+
                     let colorLibraryFiles = readdirSync(libraryFolder).filter(item => {
                         return extname(item) === '.sketch';
                     }).map(item => {
                         return libraryFolder + item;
                     });
-        
+
                     colorLibraryFiles.forEach(item => {
                         if (!allLibraries.includes(item)) {
                             unlinkSync(item);

--- a/src/lib/act-to-colors.js
+++ b/src/lib/act-to-colors.js
@@ -1,0 +1,52 @@
+import { UI } from 'sketch';
+import { Buffer } from 'buffer';
+import { readFileSync } from '@skpm/fs';
+import color from './color';
+
+/**
+ * Convert Adobe Color Table (ACT) file to Array [{ name, color }]
+ * File format specification:
+ * https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577411_pgfId-1070626
+ * @param {string} filePath
+ * @returns {Array} [ {name, color} ]
+ */
+export default function(filePath) {
+  let colorContents = readFileSync(filePath);
+  let colorBuffer = Buffer.from(colorContents);
+
+  // should be 768 or 772 bytes long
+  if (colorBuffer.length !== 768 && colorBuffer.length !== 772) {
+    UI.message('Error: Not a valid Adobe Color Table (ACT) file.');
+    return;
+  }
+
+  let numColors = 255;
+
+  // If file is 772 bytes long, there are 4 additional bytes remaining
+  if (colorBuffer.length === 772) {
+    // Two bytes for the number of colors to use.
+    numColors = colorBuffer.slice(-4).readInt16BE();
+  }
+
+  let colors = [];
+
+  let i = 0;
+
+  while (i < numColors * 3) {
+    let r = colorBuffer.slice(i, i + 1).readUInt8(0);
+    let g = colorBuffer.slice(i + 1, i + 2).readUInt8(0);
+    let b = colorBuffer.slice(i + 2, i + 3).readUInt8(0);
+
+    const nscolor = color.colorWithRGBA(r, g, b, 1);
+    const hexValue = color.toHexValue(nscolor);
+
+    colors.push({
+      name: hexValue,
+      color: hexValue,
+    });
+
+    i += 3;
+  }
+
+  return colors;
+}


### PR DESCRIPTION
This PR adds support for importing Adobe Color Table (ACT) files.

1. Install the plugin with these changes.
2. Download an ACT file, for example from [Fornaxvoid's color palettes](http://fornaxvoid.com/colorpalettes/).
3. Import the ACT file from the plugin.
4. Colors should now be imported to your palette.

There are two kinds of formats that an ACT file can be. One contains all 255 colors and the other only contains _n_ number of colors.

You can read more about it in the [Adobe Photoshop File Format Specification](https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577411_pgfId-1070626)